### PR TITLE
Validating target identical variants

### DIFF
--- a/mavehgvs/variant.py
+++ b/mavehgvs/variant.py
@@ -181,7 +181,7 @@ class Variant:
             else:  # pragma: no cover
                 raise ValueError("invalid variant count")
 
-        if targetseq is not None:
+        if targetseq is not None and not self.is_target_identical():
             for vtype, pos, seq in self.variant_tuples():
                 if vtype == "sub":
                     if self._prefix == "p":

--- a/tests/test_variant.py
+++ b/tests/test_variant.py
@@ -403,6 +403,23 @@ class TestCreateMultiVariantFromValues(unittest.TestCase):
 
 
 class TestTargetSequenceValidation(unittest.TestCase):
+    def test_target_identity(self):
+        variant_tuples = [
+            ("ACGT", "g.="),
+            ("ACGT", "m.="),
+            ("ACGT", "o.="),
+            ("ACGT", "c.="),
+            ("ACGT", "n.="),
+            ("ACGU", "r.="),
+            ("RCQY", "p.="),
+            ("RCQY", "p.(=)"),
+        ]
+
+        for target, s in variant_tuples:
+            with self.subTest(target=target, s=s):
+                v = Variant(s, targetseq=target)
+                self.assertEqual(s, str(v))
+
     def test_matching_dna_substitution(self):
         variant_tuples = [
             ("ACGT", "c.1A>T"),


### PR DESCRIPTION
Fixes a 500 error on the MaveDB server when trying to validate against the target sequence for datasets with target-identical variants.