### PR TITLE
feat: Add components method to Variant class

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,11 +12,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/tests/test_variant.py
+++ b/tests/test_variant.py
@@ -987,6 +987,30 @@ class TestMiscMethods(unittest.TestCase):
                 v = Variant(s)
                 self.assertTrue(v.uses_extended_positions())
 
+    def test_components(self):
+        variant_strings = [
+            ("p.[Glu27Trp;Ter345Lys]", ("p.Glu27Trp", "p.Ter345Lys")),
+            ("p.[Glu27Trp;Lys212fs]", ("p.Glu27Trp", "p.Lys212fs")),
+            (
+                "p.[Gly18del;Glu27Trp;Ter345Lys]",
+                ("p.Gly18del", "p.Glu27Trp", "p.Ter345Lys"),
+            ),
+            (
+                "p.[Gln7_Asn19del;Glu27Trp;Ter345Lys]",
+                ("p.Gln7_Asn19del", "p.Glu27Trp", "p.Ter345Lys"),
+            ),
+            (
+                "c.[1_35del;78+5_78+10del;122T>A]",
+                ("c.1_35del", "c.78+5_78+10del", "c.122T>A"),
+            ),
+            ("p.Glu27Trp", ("p.Glu27Trp",)),
+        ]
+
+        for s, expected_components in variant_strings:
+            with self.subTest(s=s):
+                v = Variant(s)
+                self.assertTrue(all([c in expected_components for c in v.components()]))
+
 
 # TODO: multi-variant test cases
 class TestMiscProperties(unittest.TestCase):


### PR DESCRIPTION
Adds a `components` method to the Variant class which is a tuple of fully qualified variant strings that comprises the current variant object. The `format_variant` function was refactored into a new function `_format_component_variants`, which returns a list of the component variants of a Variant object. In turn, the __repr__ function uses this class function to return the variant string representation. The `components` method returns the result of this new internal formatting function, with the prefix and transcript identifier prepended to each variant string.

For multi-variants, each tuple element is parsable into a single-variant Variant object which comprises the original multi-variant. For single- variants, the single element tuple contains the original variant string.

Closes #39.